### PR TITLE
测试一下Diff.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')2221222
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
 run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
 123
-; 将启动参数数组 转为字符串，每组参数用双引号括起来。
+; 将启动参数数组 转为字符串，每组参数用双引号括起来。2345
 args := ""
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ os.system(f'cd /d {dirPath}')
 os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
 run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
-
+123
 ; 将启动参数数组 转为字符串，每组参数用双引号括起来。
 args := ""
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ dirPath = os.getcwd()
 os.system(f'cd /d {dirPath}')
 os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')2221222
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
-run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
+run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称趣味儿童
 123
 ; 将启动参数数组 转为字符串，每组参数用双引号括起来。2345
 args := ""

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')2221222
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
 run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称趣味儿童
 123
-; 将启动参数数组 转为字符串，每组参数用双引号括起来。2345
+; 将启动参数数组 转为字符串，每组参数用双引号括起来。2345沃尔特遇见你把v出现
 args := ""
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')2221222
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
 run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称趣味儿童
 123
-; 将启动参数数组 转为字符串，每组参数用双引号括起来。2345沃尔特遇见你把v出现
+; 将启动参数数组 转为字符串，每组参数用双引号括起来。2345沃尔特遇见你把v出现123456
 args := ""
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
 
 ; 将启动参数数组 转为字符串，每组参数用双引号括起来。
 args := ""
+
+
+; 检查命名管道，若存在则通过管道传指令
+if FileExist(pipe_name)
+{
+    Sleep, 30 ; 等待一段时间让服务端重启管道
+    FileEncoding UTF-8 ; 设置文件写入的编码类型为UTF8
+    pipe := FileOpen(pipe_name, "w")
+    if (ErrorLevel) {
+        MsgBox, 16, Error, 打开命名管道%pipe_name%失败。
+pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
+run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
+
+; 将启动参数数组 转为字符串，每组参数用双引号括起来。
+args := ""
 if A_Args.Length() = 0 ; 空参数，则显示主窗
 {
     args = "-show"
@@ -44,6 +59,64 @@ else
             MsgBox 未找到主程序【%run_name%】。请将命令行入口放在主程序相同或子文件夹中。
             return 
         }
+        run_name = %run_name_p%
+    }
+    Run, %run_name% %args%
+}
+else
+{
+    if !FileExist(run_name) ; 检查同级路径
+    {
+        run_name_p := "..\" . run_name ; 检查父路径
+        if !FileExist(run_name_p)
+        {
+            MsgBox 未找到主程序【%run_name%】。请将命令行入口放在主程序相同或子文件夹中。
+            return 
+        }
+        pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
+run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
+
+; 将启动参数数组 转为字符串，每组参数用双引号括起来。
+args := ""
+if A_Args.Length() = 0 ; 空参数，则显示主窗
+{
+    args = "-show"
+}
+else
+{
+    for index, value in A_Args
+    {
+        args .= """" . value . """ "
+    }
+}
+
+; 检查命名管道，若存在则通过管道传指令
+if FileExist(pipe_name)
+{
+    Sleep, 30 ; 等待一段时间让服务端重启管道
+    FileEncoding UTF-8 ; 设置文件写入的编码类型为UTF8
+    pipe := FileOpen(pipe_name, "w")
+    if (ErrorLevel) {
+        MsgBox, 16, Error, 打开命名管道%pipe_name%失败。
+        return
+    }
+    pipe.Write(args) ; 向管道写入指令
+}
+; 若不存在则启动Umi-OCR软件，通过启动参数传指令
+else
+{
+    if !FileExist(run_name) ; 检查同级路径
+    {
+        run_name_p := "..\" . run_name ; 检查父路径
+        if !FileExist(run_name_p)
+        {
+            MsgBox 未找到主程序【%run_name%】。请将命令行入口放在主程序相同或子文件夹中。
+            return 
+        }
+        run_name = %run_name_p%
+    }
+    Run, %run_name% %args%
+}
         run_name = %run_name_p%
     }
     Run, %run_name% %args%

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ import os
 dirPath = os.getcwd()
 
 os.system(f'cd /d {dirPath}')
-os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')
+os.system(r'pipreqs ./ --encoding=utf8 --force --use-local')2221222
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
 run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
 123

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ if FileExist(pipe_name)
 pipe_name := "\\.\pipe\umiocr" ; 命名管道名称
 run_name := "Umi-OCR 文字识别.exe" ; 启动程序名称
 
-; 将启动参数数组 转为字符串，每组参数用双引号括起来。
+; 将启动参数数组 转为字符串，每组参数用双引号括起来沃尔特呀。
 args := ""
 if A_Args.Length() = 0 ; 空参数，则显示主窗
 {


### PR DESCRIPTION
1234567890-098764321234567

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details>

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details><details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details><details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details><details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details><details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details><details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - args
> - pipe
> #### Testing
> Ensure that the program can open the named pipe and write the arguments to it, or if the pipe doesn't exist, run the Umi-OCR software with the arguments.
> #### Reasoning
> This change allows the program to pass arguments to the Umi-OCR software either through a named pipe or directly when the pipe doesn't exist.
</details>